### PR TITLE
Includes biomarker name in row label.

### DIFF
--- a/src/groovy/jobs/steps/ValueGroupDumpDataStep.groovy
+++ b/src/groovy/jobs/steps/ValueGroupDumpDataStep.groovy
@@ -2,6 +2,7 @@ package jobs.steps
 
 import org.transmartproject.core.dataquery.DataRow
 import org.transmartproject.core.dataquery.highdim.AssayColumn
+import org.transmartproject.core.dataquery.highdim.BioMarkerDataRow
 
 class ValueGroupDumpDataStep extends AbstractDumpHighDimensionalDataStep {
 
@@ -15,7 +16,8 @@ class ValueGroupDumpDataStep extends AbstractDumpHighDimensionalDataStep {
         [
                 getRowKey(subsetName, seriesName, column.patientInTrialId),
                 row[column],
-                row.label
+                (row instanceof BioMarkerDataRow) ?
+                    [row.label, row.bioMarker].join("_") : row.label
         ]
     }
 


### PR DESCRIPTION
In addition to the probe id. Applies to heatmap, kmeans and hierarchical clustering.

Alternatively, it could be changed in core-db (ProbeRow, etc.), but this seems a more appropriate place.
