### PR TITLE
ScatterPlot had hardcoded restriction for plotting

### DIFF
--- a/web-app/Rscripts/ScatterPlot/ScatterPlotLoader.R
+++ b/web-app/Rscripts/ScatterPlot/ScatterPlotLoader.R
@@ -169,7 +169,7 @@ ScatterPlot.loader <- function(
 			tmp <- tmp + stat_smooth(method="lm", se=FALSE,size=1.25) 
 			tmp <- tmp + aes(colour = GROUP.1) 
 			tmp <- tmp + aes(shape = GROUP.1) 
-			tmp <- tmp + scale_shape_manual(values=1:20)
+			tmp <- tmp + scale_shape_manual(values=rep_len(1:25,length.out = length(unique(line.data$GROUP))))
 			tmp <- tmp + scale_colour_brewer("GROUP.1")
 			tmp <- tmp + scale_x_continuous(modifiedXAxisLabel) 
 			tmp <- tmp + scale_y_continuous(yAxisLabel)
@@ -192,7 +192,7 @@ ScatterPlot.loader <- function(
 		tmp <- tmp + stat_smooth(method="lm", se=FALSE,size=1.25) 
 		tmp <- tmp + aes(colour = GROUP) 
 		tmp <- tmp + aes(shape = GROUP) 
-		tmp <- tmp + scale_shape_manual(values=1:20)
+		tmp <- tmp + scale_shape_manual(values=rep_len(1:25,length.out = length(unique(line.data$GROUP))))
 		tmp <- tmp + scale_x_continuous(xAxisLabel) 
 		tmp <- tmp + scale_y_continuous(yAxisLabel)
 		


### PR DESCRIPTION
The plot had hardcoded restriction of only 20 groups. Recoded handling
of point-shapes in plot to dynamic range.
