### PR TITLE
Added data requirements check before Fisher test

### DIFF
--- a/web-app/Rscripts/TableWithFisher/FisherTableLoader.R
+++ b/web-app/Rscripts/TableWithFisher/FisherTableLoader.R
@@ -98,7 +98,14 @@ FisherTable.loader.single <- function(dataChunk,splitColumn,fileNameQualifier)
 	
 	#Generate count table.
 	countTable <- table(dataChunk)
-	
+
+	#Do not continue with statistical tests if data requirements are not met
+    if (nlevels(dataChunk$X) < 2 || nlevels(dataChunk$Y) < 2) {
+      write(paste("Not enough levels for Fisher or chi-square test."), file=statisticalTestsResultsFile,append=T)
+      write.table(countTable,countsFile,quote=F,sep="\t",row.names=T,col.names=T,append=T)
+      return()
+    }
+
 	#Get fisher test statistics.
 	fisherResults <- fisher.test(countTable,simulate.p.value=TRUE)
 		


### PR DESCRIPTION
Before, a single group without proper amount of levels would cause
exception for entire analysis. This is now caught.
