### PR TITLE
Internet Explorer 8 cannot count nodes being dropped in High Dimensional input

### DIFF
--- a/web-app/js/FormValidator.js
+++ b/web-app/js/FormValidator.js
@@ -142,7 +142,7 @@ FormValidator.prototype.required = function (el, label) {
     var retVal = true;
 
     if (el instanceof Ext.Element) {  // if input element is instance of Ext JS
-        retVal = el.dom.childElementCount > 0 ? true : false;
+        retVal = el.dom.children.length > 0 ? true : false;
     } else {
         var value = el.value;
         retVal = (value !== null && value !== '');


### PR DESCRIPTION
To replace childElementCount with children.length since childElementCount is not supported in Internet Explorer 8. This is related to UAT-29.
