### PR TITLE
ColumnConfigurators: add header as common property

### DIFF
--- a/src/groovy/jobs/CategoricalOrBinnedJob.groovy
+++ b/src/groovy/jobs/CategoricalOrBinnedJob.groovy
@@ -54,7 +54,7 @@ abstract class CategoricalOrBinnedJob extends AbstractAnalysisJob implements Ini
                                          String keyVariablePart,
                                          String header = null) {
         if (header != null) {
-            configurator.columnHeader = header
+            configurator.header = header
         }
         configurator.projection            = Projection.LOG_INTENSITY_PROJECTION
 

--- a/src/groovy/jobs/HighDimensionalOnlyJob.groovy
+++ b/src/groovy/jobs/HighDimensionalOnlyJob.groovy
@@ -23,13 +23,13 @@ abstract class HighDimensionalOnlyJob extends AbstractAnalysisJob {
         def independentConfigurator = appCtx.getBean NumericColumnConfigurator
 
         dependentConfigurator = new NumericColumnConfigurator(
-                columnHeader: 'X',
+                header: 'X',
                 projection: Projection.ZSCORE_PROJECTION,
                 keyForConceptPath: 'dependentVariable',
                 keyForDataType: 'divDependentVariableType',
                 keyForSearchKeywordId: 'divDependentVariablePathway')
         independentConfigurator = new NumericColumnConfigurator(
-                columnHeader: 'Y',
+                header: 'Y',
                 projection: Projection.ZSCORE_PROJECTION,
                 keyForConceptPath: 'independentVariable',
                 keyForDataType: 'divIndependentVariableType',

--- a/src/groovy/jobs/LineGraph.groovy
+++ b/src/groovy/jobs/LineGraph.groovy
@@ -44,7 +44,7 @@ class LineGraph extends AbstractAnalysisJob {
     void init() {
         primaryKeyColumnConfigurator.column = new PrimaryKeyColumn(header: 'PATIENT_NUM')
 
-        measurementConfigurator.columnHeader          = 'VALUE'
+        measurementConfigurator.header                = 'VALUE'
         measurementConfigurator.projection            = Projection.LOG_INTENSITY_PROJECTION
         measurementConfigurator.multiRow              = true
         measurementConfigurator.multiConcepts         = true
@@ -55,7 +55,7 @@ class LineGraph extends AbstractAnalysisJob {
         measurementConfigurator.keyForDataType        = 'divDependentVariableType'
         measurementConfigurator.keyForSearchKeywordId = 'divDependentVariablePathway'
 
-        groupByColumnConfigurator.columnHeader        = 'GROUP_VAR'
+        groupByColumnConfigurator.header              = 'GROUP_VAR'
         groupByColumnConfigurator.projection          = Projection.LOG_INTENSITY_PROJECTION
         groupByColumnConfigurator.multiRow            = true
         groupByColumnConfigurator.keyForIsCategorical = 'groupByVariableCategorical'

--- a/src/groovy/jobs/ScatterPlot.groovy
+++ b/src/groovy/jobs/ScatterPlot.groovy
@@ -60,9 +60,9 @@ class ScatterPlot extends AbstractAnalysisJob {
     private void configureConfigurator(NumericColumnConfigurator configurator,
                                        String key,
                                        String header) {
-        configurator.columnHeader          = header
-        configurator.projection            = Projection.LOG_INTENSITY_PROJECTION
-        configurator.multiRow              = true
+        configurator.header     = header
+        configurator.projection = Projection.LOG_INTENSITY_PROJECTION
+        configurator.multiRow   = true
 
         configurator.setKeys(key)
     }

--- a/src/groovy/jobs/SurvivalAnalysis.groovy
+++ b/src/groovy/jobs/SurvivalAnalysis.groovy
@@ -52,14 +52,14 @@ class SurvivalAnalysis extends AbstractAnalysisJob implements InitializingBean {
     }
 
     void configureTimeVariableConfigurator() {
-        timeVariableConfigurator.columnHeader   = 'TIME'
+        timeVariableConfigurator.header = 'TIME'
         timeVariableConfigurator.setKeys('time')
         timeVariableConfigurator.alwaysClinical = true
     }
 
     void configureCategoryVariableConfigurator() {
         categoryVariableConfigurator.required = false
-        categoryVariableConfigurator.columnHeader       = 'CATEGORY'
+        categoryVariableConfigurator.header             = 'CATEGORY'
         categoryVariableConfigurator.projection         = Projection.LOG_INTENSITY_PROJECTION
         categoryVariableConfigurator.multiRow           = true
 
@@ -77,9 +77,9 @@ class SurvivalAnalysis extends AbstractAnalysisJob implements InitializingBean {
 
     void configureCensoringVariableConfigurator() {
 
-        censoringInnerConfigurator.required             = false
-        censoringInnerConfigurator.columnHeader         = 'CENSOR'
-        censoringInnerConfigurator.keyForConceptPaths   = 'censoringVariable'
+        censoringInnerConfigurator.required           = false
+        censoringInnerConfigurator.header             = 'CENSOR'
+        censoringInnerConfigurator.keyForConceptPaths = 'censoringVariable'
 
         def noValueDefault = censoringInnerConfigurator.getConceptPaths() ? CENSORING_FALSE : CENSORING_TRUE
 

--- a/src/groovy/jobs/steps/helpers/BoxPlotVariableColumnConfigurator.groovy
+++ b/src/groovy/jobs/steps/helpers/BoxPlotVariableColumnConfigurator.groovy
@@ -46,13 +46,13 @@ class BoxPlotVariableColumnConfigurator extends OptionalBinningColumnConfigurato
     }
 
     @Override
-    void setColumnHeader(String header) {
+    void setHeader(String header) {
         throw new UnsupportedOperationException(
                 'Column header is automatically assigned')
     }
 
     @Override
-    String getColumnHeader() {
+    String getHeader() {
         categoricalOrBinned ?
                 categoricalColumnHeader :
                 numericColumnHeader

--- a/src/groovy/jobs/steps/helpers/CategoricalColumnConfigurator.groovy
+++ b/src/groovy/jobs/steps/helpers/CategoricalColumnConfigurator.groovy
@@ -12,8 +12,6 @@ import org.transmartproject.core.dataquery.clinical.ClinicalVariable
 @Scope('prototype')
 class CategoricalColumnConfigurator extends ColumnConfigurator {
 
-    String columnHeader
-
     String keyForConceptPaths
 
     @Autowired
@@ -39,12 +37,15 @@ class CategoricalColumnConfigurator extends ColumnConfigurator {
             table.addColumn(
                     decorateColumn.call(
                             new CategoricalVariableColumn(
-                                    header: columnHeader,
+                                    header:    header,
                                     leafNodes: variables)),
                     [ClinicalDataRetriever.DATA_SOURCE_NAME] as Set)
         } else {
             //optional, empty value column
-            table.addColumn(new ConstantValueColumn(header: columnHeader, missingValueAction: missingValueAction), Collections.emptySet())
+            table.addColumn(new ConstantValueColumn(
+                            header: header,
+                            missingValueAction: missingValueAction),
+                    Collections.emptySet())
         }
     }
 

--- a/src/groovy/jobs/steps/helpers/ColumnConfigurator.groovy
+++ b/src/groovy/jobs/steps/helpers/ColumnConfigurator.groovy
@@ -16,8 +16,11 @@ abstract class ColumnConfigurator {
     @Autowired
     private Table table
 
+    String header
+
     MissingValueAction missingValueAction
 
+    @Deprecated // use OptionalBinningColumnDecorator instead
     boolean required = true
 
     final void addColumn() {
@@ -28,6 +31,27 @@ abstract class ColumnConfigurator {
         if (!missingValueAction) {
             doAddColumn decorateColumn
         } else {
+            /* we don't do the same sort of thing for header because, unlike the
+             * MissingValueAction, which only matters on the outer layer (i.e.,
+             * the Column that is actually added to the table, not its eventual
+             * inner columns), the header has to be propagated all over the
+             * place, at least under the current scheme of things. Let's take
+             * the example of a binning column decorator wrapping a simple
+             * numeric column. The decorator actually delegates getHeader() to
+             * the numeric column, which means the numeric column, which is the
+             * innermost column, needs to have its header set. Wrapping the
+             * outermost column (the binning column decorator) in a decorator
+             * like ReplaceMissingValueActionDecorator() would not help because
+             * this replacement happens on the outside of the binning column.
+             *
+             * In essence, the problem is that header serves two purposes. For
+             * the outside (i.e., Table), it is the header of the column to be
+             * put on the first line of the CSV. But, unlike the missing value
+             * action, it is also used internally by the binning decorators
+             * to build the values of the column. Therefore, it is not
+             * sufficient for the header value to be available only to the
+             * outside via a decorator.
+             */
             doAddColumn(compose(
                     { Column it ->
                         new ReplaceMissingValueActionDecorator(

--- a/src/groovy/jobs/steps/helpers/ContextNumericVariableColumnConfigurator.groovy
+++ b/src/groovy/jobs/steps/helpers/ContextNumericVariableColumnConfigurator.groovy
@@ -34,7 +34,7 @@ class ContextNumericVariableColumnConfigurator extends ColumnConfigurator {
 
     /* properties to be set externally:
      *
-     * - columnHeader
+     * - header
      * - projection
      * - keyForConceptPaths/keyForConceptPath (indifferent which)
      * - keyForDataType

--- a/src/groovy/jobs/steps/helpers/HighDimensionColumnConfigurator.groovy
+++ b/src/groovy/jobs/steps/helpers/HighDimensionColumnConfigurator.groovy
@@ -29,8 +29,6 @@ import static jobs.steps.OpenHighDimensionalDataStep.createConceptKeyFrom
 @Scope('prototype')
 class HighDimensionColumnConfigurator extends ColumnConfigurator {
 
-    String columnHeader
-
     String projection
 
     String keyForConceptPath,
@@ -148,11 +146,15 @@ class HighDimensionColumnConfigurator extends ColumnConfigurator {
                     "Found empty concept paths list (key $keyForConceptPath)")
         }
 
+        if (!header) {
+            throw new IllegalStateException('header property must be set')
+        }
+
         Map<String, TabularResult> tabularResults
         Set<String> commonPatients
         if (conceptPaths.size() == 1 && !multiConcepts) {
             tabularResults = ImmutableMap.of(
-                    columnHeader + '_highdim',
+                    header + '_highdim',
                     openResultSet(conceptPaths[0]))
         } else {
             if (!multiConcepts) {
@@ -173,10 +175,10 @@ class HighDimensionColumnConfigurator extends ColumnConfigurator {
         def highDimColumn
         if (!multiRow) {
             highDimColumn = new HighDimensionSingleRowResultColumn(
-                    header: columnHeader)
+                    header: header)
         } else {
             highDimColumn = new HighDimensionMultipleRowsResultColumn(
-                    header:             columnHeader,
+                    header:             header,
                     patientsToConsider: commonPatients)
         }
         table.addColumn(

--- a/src/groovy/jobs/steps/helpers/MultiNumericClinicalVariableColumnConfigurator.groovy
+++ b/src/groovy/jobs/steps/helpers/MultiNumericClinicalVariableColumnConfigurator.groovy
@@ -13,8 +13,6 @@ import org.transmartproject.core.dataquery.clinical.ClinicalVariableColumn
 @Scope('prototype')
 class MultiNumericClinicalVariableColumnConfigurator extends ColumnConfigurator {
 
-    String columnHeader
-
     String keyForConceptPaths
 
     boolean pruneConceptPath = true
@@ -48,7 +46,7 @@ class MultiNumericClinicalVariableColumnConfigurator extends ColumnConfigurator 
                 decorateColumn.call(
                         new MultiNumericClinicalVariableColumn(
                                 clinicalVariables: variableToGroupName,
-                                header:            columnHeader)),
+                                header:            header)),
                 [ClinicalDataRetriever.DATA_SOURCE_NAME] as Set)
     }
 

--- a/src/groovy/jobs/steps/helpers/NumericColumnConfigurator.groovy
+++ b/src/groovy/jobs/steps/helpers/NumericColumnConfigurator.groovy
@@ -13,8 +13,6 @@ class NumericColumnConfigurator extends ColumnConfigurator {
 
     public static final String CLINICAL_DATA_TYPE_VALUE = 'CLINICAL'
 
-    String columnHeader
-
     String projection             /* only applicable for high dim data */
 
     String keyForConceptPath,
@@ -48,7 +46,7 @@ class NumericColumnConfigurator extends ColumnConfigurator {
     }
 
     private void addColumnHighDim(Closure<Column> decorateColumn) {
-        ['columnHeader', 'projection', 'keyForConceptPath', 'keyForDataType',
+        ['header', 'projection', 'keyForConceptPath', 'keyForDataType',
                 'keyForSearchKeywordId', 'multiRow'].each { prop ->
             highDimensionColumnConfigurator."$prop" = this."$prop"
         }
@@ -67,7 +65,7 @@ class NumericColumnConfigurator extends ColumnConfigurator {
                         new SimpleConceptVariableColumn(
                                 column:      variable,
                                 numbersOnly: true,
-                                header:      columnHeader)),
+                                header:      header)),
                 [ClinicalDataRetriever.DATA_SOURCE_NAME] as Set)
     }
 

--- a/src/groovy/jobs/steps/helpers/OptionalBinningColumnConfigurator.groovy
+++ b/src/groovy/jobs/steps/helpers/OptionalBinningColumnConfigurator.groovy
@@ -30,8 +30,6 @@ class OptionalBinningColumnConfigurator extends ColumnConfigurator {
     @Autowired
     BinningColumnConfigurator binningConfigurator
 
-    String columnHeader
-
     String projection
 
     String keyForConceptPaths,
@@ -62,9 +60,9 @@ class OptionalBinningColumnConfigurator extends ColumnConfigurator {
                     "assuming constant value column")
 
             innerConfigurator = appCtx.getBean SimpleAddColumnConfigurator
-            innerConfigurator.column = new ConstantValueColumn(header: columnHeader, missingValueAction: missingValueAction)
-            //innerConfigurator.missingValueAction = missingValueAction
-            //table.addColumn(new ConstantValueColumn(header: columnHeader, missingValueAction: missingValueAction), Collections.emptySet())
+            innerConfigurator.column = new ConstantValueColumn(
+                    header:             getHeader(),
+                    missingValueAction: missingValueAction)
             innerConfigurator.addColumn()
 
         } else if (categorical) {
@@ -73,7 +71,7 @@ class OptionalBinningColumnConfigurator extends ColumnConfigurator {
 
             innerConfigurator = appCtx.getBean CategoricalColumnConfigurator
 
-            innerConfigurator.columnHeader       = getColumnHeader()
+            innerConfigurator.header             = getHeader()
             innerConfigurator.keyForConceptPaths = keyForConceptPaths
         } else {
             log.debug("Did not find pipe character in $keyForConceptPaths, " +
@@ -81,7 +79,7 @@ class OptionalBinningColumnConfigurator extends ColumnConfigurator {
 
             innerConfigurator = appCtx.getBean numericColumnConfigurationClass
 
-            innerConfigurator.columnHeader          = getColumnHeader()
+            innerConfigurator.header                = getHeader()
             innerConfigurator.projection            = projection
             innerConfigurator.keyForConceptPath     = keyForConceptPaths
             innerConfigurator.keyForDataType        = keyForDataType
@@ -105,7 +103,7 @@ class OptionalBinningColumnConfigurator extends ColumnConfigurator {
                     !(innerConfigurator instanceof CategoricalColumnConfigurator) &&
                     forceNumericBinning) {
                 throw new InvalidArgumentsException("Numeric variables must be " +
-                        "binned for column $columnHeader")
+                        "binned for column ${getHeader()}")
             }
             
             //configure binning only if has variable

--- a/src/groovy/jobs/table/Table.groovy
+++ b/src/groovy/jobs/table/Table.groovy
@@ -75,11 +75,23 @@ class Table implements AutoCloseable {
                     "data sources: $difference")
         }
 
+        validateColumn col
+
         columns << col
         columnsToIndex[col] = columns.size() - 1
 
         for (dataSourceName in subscribedDataSources) {
             dataSourceSubscriptions.put(dataSources[dataSourceName], col)
+        }
+    }
+
+    private validateColumn(Column column) {
+        if (!column.header) {
+            throw new IllegalStateException("Header not set on column $column")
+        }
+        if (!column.missingValueAction) {
+            throw new IllegalStateException(
+                    "Missing value action not set on column $column")
         }
     }
 

--- a/src/groovy/jobs/table/columns/binning/EvenDistributionBinningColumnDecorator.groovy
+++ b/src/groovy/jobs/table/columns/binning/EvenDistributionBinningColumnDecorator.groovy
@@ -146,5 +146,14 @@ class EvenDistributionBinningColumnDecorator implements ColumnDecorator {
             (Object) entry.value /* the name of the bin */
         }
     }
+
+    void beforeDataSourceIteration(String dataSourceName, Iterable dataSource) {
+        // just for validation
+        if (!header) {
+            throw new IllegalStateException('Bug: header not set here')
+        }
+
+        inner.beforeDataSourceIteration dataSourceName, dataSource
+    }
 }
 

--- a/src/groovy/jobs/table/columns/binning/EvenSpacedBinningColumnDecorator.groovy
+++ b/src/groovy/jobs/table/columns/binning/EvenSpacedBinningColumnDecorator.groovy
@@ -89,4 +89,13 @@ class EvenSpacedBinningColumnDecorator implements ColumnDecorator {
                     (Number) ((value instanceof Number) ? value : (value as BigDecimal)))
         }
     }
+
+    void beforeDataSourceIteration(String dataSourceName, Iterable dataSource) {
+        // just for validation
+        if (!header) {
+            throw new IllegalStateException('Bug: header not set here')
+        }
+
+        inner.beforeDataSourceIteration dataSourceName, dataSource
+    }
 }

--- a/src/groovy/jobs/table/columns/binning/NumericManualBinningColumnDecorator.groovy
+++ b/src/groovy/jobs/table/columns/binning/NumericManualBinningColumnDecorator.groovy
@@ -66,4 +66,13 @@ class NumericManualBinningColumnDecorator implements ColumnDecorator {
         }
     }
 
+    void beforeDataSourceIteration(String dataSourceName, Iterable dataSource) {
+        // just for validation
+        if (!header) {
+            throw new IllegalStateException('Bug: header not set here')
+        }
+
+        inner.beforeDataSourceIteration dataSourceName, dataSource
+    }
+
 }

--- a/test/integration/jobs/steps/helpers/BoxPlotVariableColumnConfiguratorTests.groovy
+++ b/test/integration/jobs/steps/helpers/BoxPlotVariableColumnConfiguratorTests.groovy
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.*
 class BoxPlotVariableColumnConfiguratorTests {
 
     public static final String VALUE_FOR_COLUMN_BEING_BINNED = 'IND'
+    public static final String TEST_HEADER = 'TEST_HEADER'
     @Autowired
     Table table
 

--- a/test/integration/jobs/steps/helpers/ContextNumericVariableColumnConfiguratorTests.groovy
+++ b/test/integration/jobs/steps/helpers/ContextNumericVariableColumnConfiguratorTests.groovy
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.*
 class ContextNumericVariableColumnConfiguratorTests {
 
     public static final String CONCEPT_PATH_HIGH_DIMENSION_EXTRA = '\\bogus\\highdim\\variable\\extra\\'
+    public static final String COLUMN_HEADER = 'SAMPLE_HEADER'
 
     @Autowired
     ContextNumericVariableColumnConfigurator testee
@@ -41,6 +42,7 @@ class ContextNumericVariableColumnConfiguratorTests {
     void init() {
         initializeAsBean configuratorTestsHelper
 
+        testee.header                = COLUMN_HEADER
         testee.projection            = Projection.DEFAULT_REAL_PROJECTION
         testee.keyForConceptPaths    = 'conceptPaths'
         testee.keyForDataType        = 'dataType'
@@ -83,7 +85,7 @@ class ContextNumericVariableColumnConfiguratorTests {
                 (CONCEPT_PATH_HIGH_DIMENSION_EXTRA): result2)
 
         play {
-            table.addColumn(new PrimaryKeyColumn(), [] as Set)
+            table.addColumn(new PrimaryKeyColumn(header: 'PK'), [] as Set)
             testee.addColumn()
 
             table.buildTable()

--- a/test/integration/jobs/steps/helpers/OptionalBinningColumnConfiguratorTests.groovy
+++ b/test/integration/jobs/steps/helpers/OptionalBinningColumnConfiguratorTests.groovy
@@ -54,7 +54,7 @@ class OptionalBinningColumnConfiguratorTests {
         }
         assertThat params.@map, is(notNullValue())
 
-        testee.columnHeader          = COLUMN_HEADER
+        testee.header                = COLUMN_HEADER
         testee.projection            = Projection.DEFAULT_REAL_PROJECTION
         testee.keyForConceptPaths    = 'variable'
         testee.keyForDataType        = 'divVariableType'
@@ -397,9 +397,9 @@ class OptionalBinningColumnConfiguratorTests {
 
         // second column to force the skipped primary key to be in the result
         // otherise the row with 66 would be just skipped
-        def secondColumn = new StubColumn(data: [
-                (createPatientRowLabels(2)[1]): 'bar'
-        ])
+        def secondColumn = new StubColumn(
+                header: 'STUB',
+                data: [(createPatientRowLabels(2)[1]): 'bar'])
         secondColumn.missingValueAction =
                 new MissingValueAction.ConstantReplacementMissingValueAction(replacement: '')
 


### PR DESCRIPTION
Replacing the columnHeader properties that existed all over the place.
