### PR TITLE
Fix extra data LineGraph

### DIFF
--- a/src/groovy/jobs/LineGraph.groovy
+++ b/src/groovy/jobs/LineGraph.groovy
@@ -5,9 +5,9 @@ import com.google.common.collect.Maps
 import jobs.steps.*
 import jobs.steps.helpers.ContextNumericVariableColumnConfigurator
 import jobs.steps.helpers.OptionalBinningColumnConfigurator
+import jobs.steps.helpers.OptionalColumnConfiguratorDecorator
 import jobs.steps.helpers.SimpleAddColumnConfigurator
 import jobs.table.ConceptTimeValuesTable
-import jobs.table.MissingValueAction
 import jobs.table.Table
 import jobs.table.columns.PrimaryKeyColumn
 import org.springframework.beans.factory.annotation.Autowired
@@ -27,9 +27,13 @@ class LineGraph extends AbstractAnalysisJob {
     @Autowired
     SimpleAddColumnConfigurator primaryKeyColumnConfigurator
 
+
     @Autowired
     @Qualifier('general')
-    OptionalBinningColumnConfigurator groupByColumnConfigurator
+    OptionalBinningColumnConfigurator innerGroupByConfigurator
+
+    @Autowired
+    OptionalColumnConfiguratorDecorator groupByConfigurator
 
     @Autowired
     ContextNumericVariableColumnConfigurator measurementConfigurator
@@ -55,23 +59,23 @@ class LineGraph extends AbstractAnalysisJob {
         measurementConfigurator.keyForDataType        = 'divDependentVariableType'
         measurementConfigurator.keyForSearchKeywordId = 'divDependentVariablePathway'
 
-        groupByColumnConfigurator.header              = 'GROUP_VAR'
-        groupByColumnConfigurator.projection          = Projection.LOG_INTENSITY_PROJECTION
-        groupByColumnConfigurator.multiRow            = true
-        groupByColumnConfigurator.keyForIsCategorical = 'groupByVariableCategorical'
-        groupByColumnConfigurator.setKeys 'groupBy'
+        innerGroupByConfigurator.projection           = Projection.LOG_INTENSITY_PROJECTION
+        innerGroupByConfigurator.multiRow             = true
+        innerGroupByConfigurator.keyForIsCategorical  = 'groupByVariableCategorical'
+        innerGroupByConfigurator.setKeys 'groupBy'
 
-        groupByColumnConfigurator.required            = false
-        groupByColumnConfigurator.missingValueAction  =
-                new MissingValueAction.ConstantReplacementMissingValueAction(replacement: 'SINGLE_GROUP')
-
-        def binningConfigurator = groupByColumnConfigurator.binningConfigurator
+        def binningConfigurator = innerGroupByConfigurator.binningConfigurator
         binningConfigurator.keyForDoBinning           = 'binningGroupBy'
         binningConfigurator.keyForManualBinning       = 'manualBinningGroupBy'
         binningConfigurator.keyForNumberOfBins        = 'numberOfBinsGroupBy'
         binningConfigurator.keyForBinDistribution     = 'binDistributionGroupBy'
         binningConfigurator.keyForBinRanges           = 'binRangesGroupBy'
         binningConfigurator.keyForVariableType        = 'variableTypeGroupBy'
+
+        groupByConfigurator.header                    = 'GROUP_VAR'
+        groupByConfigurator.generalCase               = innerGroupByConfigurator
+        groupByConfigurator.keyForEnabled             = 'groupByVariable'
+        groupByConfigurator.setConstantColumnFallback 'SINGLE_GROUP'
 
         conceptTimeValues.conceptPaths = measurementConfigurator.getConceptPaths()
         conceptTimeValues.enabledClosure = { -> !Boolean.parseBoolean(params.getProperty('plotEvenlySpaced')) }
@@ -89,7 +93,7 @@ class LineGraph extends AbstractAnalysisJob {
                 table:         table,
                 configurators: [primaryKeyColumnConfigurator,
                                 measurementConfigurator,
-                                groupByColumnConfigurator])
+                                groupByConfigurator])
 
         steps << new LineGraphDumpTableResultsStep(
                 table:              table,

--- a/src/groovy/jobs/steps/helpers/ColumnConfigurator.groovy
+++ b/src/groovy/jobs/steps/helpers/ColumnConfigurator.groovy
@@ -88,7 +88,7 @@ abstract class ColumnConfigurator {
                     "been provided by the client")
         }
 
-        if (!(v instanceof String)) {
+        if (v && !(v instanceof String)) {
             throw new InvalidArgumentsException("Expected the parameter '$key' " +
                     "to be a String, got a ${v.getClass()}")
         }

--- a/src/groovy/jobs/steps/helpers/OptionalColumnConfiguratorDecorator.groovy
+++ b/src/groovy/jobs/steps/helpers/OptionalColumnConfiguratorDecorator.groovy
@@ -1,0 +1,51 @@
+package jobs.steps.helpers
+
+import jobs.table.Column
+import jobs.table.columns.ConstantValueColumn
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.Scope
+import org.springframework.stereotype.Component
+
+@Component
+@Scope('prototype')
+class OptionalColumnConfiguratorDecorator extends ColumnConfigurator {
+
+    @Autowired
+    ApplicationContext ctx
+
+    ColumnConfigurator generalCase
+
+    ColumnConfigurator fallback
+
+    /* if this param is non empty, it will be considered provided */
+    String keyForEnabled
+
+    @Override
+    protected void doAddColumn(Closure<Column> decorateColumn) {
+        ColumnConfigurator configuratorToUse
+
+        if (getStringParam(keyForEnabled, false)) {
+            configuratorToUse = generalCase
+        } else {
+            configuratorToUse = fallback
+        }
+
+        if (!configuratorToUse.header) {
+            configuratorToUse.header = header
+        }
+
+        configuratorToUse.doAddColumn decorateColumn
+    }
+
+    void setConstantColumnFallback(Object columnValue) {
+        if (!header) {
+            throw new IllegalStateException(
+                    'Set this configurator\'s header before calling this method')
+        }
+        SimpleAddColumnConfigurator c = ctx.getBean(SimpleAddColumnConfigurator)
+        c.column = new ConstantValueColumn(header: header,
+                                           value:  columnValue)
+        fallback = c
+    }
+}

--- a/src/groovy/jobs/steps/helpers/SimpleAddColumnConfigurator.groovy
+++ b/src/groovy/jobs/steps/helpers/SimpleAddColumnConfigurator.groovy
@@ -12,6 +12,10 @@ class SimpleAddColumnConfigurator extends ColumnConfigurator {
 
     @Override
     protected void doAddColumn(Closure<Column> decorateColumn) {
+        if (header && header != column.header) {
+            throw new IllegalStateException('This configurator cannot ' +
+                    'control the resulting column\'s header')
+        }
         table.addColumn column, ([] as Set)
     }
 }

--- a/src/groovy/jobs/table/columns/AbstractColumn.groovy
+++ b/src/groovy/jobs/table/columns/AbstractColumn.groovy
@@ -32,4 +32,12 @@ abstract class AbstractColumn implements Column {
     Closure<Object> getValueTransformer() {
         null
     }
+
+
+    @Override
+    public String toString() {
+        com.google.common.base.Objects.toStringHelper(this).
+                add("header", header).
+                toString();
+    }
 }

--- a/test/integration/jobs/steps/helpers/OptionalBinningColumnConfiguratorTests.groovy
+++ b/test/integration/jobs/steps/helpers/OptionalBinningColumnConfiguratorTests.groovy
@@ -5,7 +5,6 @@ import grails.test.mixin.TestMixin
 import jobs.UserParameters
 import jobs.table.MissingValueAction
 import jobs.table.Table
-import jobs.table.columns.AbstractColumn
 import org.junit.After
 import org.junit.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -630,22 +629,4 @@ class OptionalBinningColumnConfiguratorTests {
             }
         }), hasProperty('message', containsString('Got non-numerical value'))
     }
-
-    static class StubColumn extends AbstractColumn {
-
-        Map<String, String> data
-
-        @Override
-        void onReadRow(String dataSourceName, Object row) {}
-
-        @Override
-        Map<String, String> consumeResultingTableRows() {
-            try {
-                return data
-            } finally {
-                data = null
-            }
-        }
-    }
-
 }

--- a/test/integration/jobs/steps/helpers/OptionalColumnConfiguratorDecoratorTests.groovy
+++ b/test/integration/jobs/steps/helpers/OptionalColumnConfiguratorDecoratorTests.groovy
@@ -1,0 +1,73 @@
+package jobs.steps.helpers
+
+import grails.test.mixin.TestMixin
+import jobs.UserParameters
+import jobs.table.Column
+import jobs.table.Table
+import org.junit.Before
+import org.junit.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.contains
+import static org.hamcrest.Matchers.is
+
+@TestMixin(JobsIntegrationTestMixin)
+class OptionalColumnConfiguratorDecoratorTests {
+
+    public static final String COLUMN_HEADER = 'SAMPLE_HEADER'
+    public static final String FALLBACK_VALUE = 'FALLBACK'
+    public static final String KEY_FOR_ENABLED = 'enabled'
+
+    @Autowired
+    OptionalColumnConfiguratorDecorator testee
+
+    @Autowired
+    SimpleAddColumnConfigurator simpleAddColumnConfigurator
+
+    @Autowired
+    Table table
+
+    @Autowired
+    UserParameters params
+
+    @Before
+    void before() {
+        Map data = [a: 1, b: 2]
+        simpleAddColumnConfigurator.column = new StubColumn(
+                header: COLUMN_HEADER, data: data)
+
+        testee.header = COLUMN_HEADER
+
+        testee.generalCase = simpleAddColumnConfigurator
+        testee.constantColumnFallback = FALLBACK_VALUE
+        testee.keyForEnabled = KEY_FOR_ENABLED
+    }
+
+    @Test
+    void testSetConstantColumnFallbackIsUsed() {
+        Column stubColumn = new StubColumn(header: COLUMN_HEADER, data: [c: 3])
+        table.addColumn stubColumn, Collections.emptySet()
+        testee.addColumn()
+
+        table.buildTable()
+
+        def res = table.result
+        assertThat res, contains(is([3, FALLBACK_VALUE]))
+    }
+
+    @Test
+    void testGoesToTheGeneralCase() {
+        params.@map.putAll([
+                (KEY_FOR_ENABLED): 'something',
+        ])
+
+        testee.addColumn()
+
+        table.buildTable()
+
+        def res = table.result
+        assertThat res, contains(is([1]), is([2]))
+    }
+
+}

--- a/test/integration/jobs/steps/helpers/StubColumn.groovy
+++ b/test/integration/jobs/steps/helpers/StubColumn.groovy
@@ -1,0 +1,19 @@
+package jobs.steps.helpers
+
+import jobs.table.columns.AbstractColumn
+
+class StubColumn extends AbstractColumn {
+    Map<String, String> data
+
+    @Override
+    void onReadRow(String dataSourceName, Object row) {}
+
+    @Override
+    Map<String, String> consumeResultingTableRows() {
+        try {
+            return data
+        } finally {
+            data = null
+        }
+    }
+}


### PR DESCRIPTION
and possibly other analyses that used OptionalBinningColumnConfigurator
with keyForIsCategorical set. Problem was that setting the
MissingValueAction to a constant value to account for the case when no
variable is selected (see UAT-176) is too strong an action. If the
selected variable doesn't have data for some patients, those patients
would nevertheless show up (under SINGLE_GROUP).

Resolved this with an OptionalColumnConfiguratorDecorator, which is
anywat what I wanted to all along. This decorator delegates to two
different sub-configurators, selected based on whether some param key is
set.

Fixes UAT-177 (likely among other problems), previously broken by the
fix for UAT-176.
