### PR TITLE
To fix the image URL which produced path that contained double backslash...

### DIFF
--- a/grails-app/services/com/recomdata/transmart/data/association/RModulesOutputRenderService.groovy
+++ b/grails-app/services/com/recomdata/transmart/data/association/RModulesOutputRenderService.groovy
@@ -95,7 +95,7 @@ class RModulesOutputRenderService {
      * @return URL path from which images will be served
      */
     private String getImageURL() {
-        '/analysisFiles/'
+        'analysisFiles/'
     }
     //</editor-fold>
 


### PR DESCRIPTION
...es so that image couldn't be displayed in all aCGH analyses.
